### PR TITLE
Person class: remove reference to dead methods in Docstring.

### DIFF
--- a/code/swapi_assignment/sw_entities.py
+++ b/code/swapi_assignment/sw_entities.py
@@ -193,8 +193,6 @@ class Person(Entity):
         species (Species): the species to which the person is assigned
 
     Methods:
-        get_homeworld: retrieve home planet
-        get_species: retrieve species
         jsonable: return JSON-friendly dict representation of the object
     """
 


### PR DESCRIPTION
Old methods removed during refactoring to free the module of package dependencies.